### PR TITLE
Allow leading zeros

### DIFF
--- a/daisypy/io/dai_grammar.py
+++ b/daisypy/io/dai_grammar.py
@@ -34,15 +34,14 @@ sequence: "(" sequence_val+ ")"
 old: "&old"
 
 bool: /true|false/
-integer.1: /0|[1-9][0-9]*/
-number: SIGNED_NUMBER
+integer.1: /[0-9]+/
+number: /-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?/
 identifier: /[a-zA-Z][a-zA-Z0-9=<>_+*\\/-]*/
 quoted_string : ESCAPED_STRING
 units: /\\[[^\\]]*\\]/
 comment: /;.*/
 
 %import common.ESCAPED_STRING
-%import common.SIGNED_NUMBER
 %import common.WS
 %ignore WS
 '''
@@ -83,8 +82,8 @@ placeholder: "{" placeholder_name "}"
 old: "&old"
 
 bool: /true|false/
-integer.1: /0|[1-9][0-9]*/
-number: SIGNED_NUMBER
+integer.1: /[0-9]+/
+number: /-?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?/
 identifier: /[a-zA-Z][a-zA-Z0-9=<>_+*\\/-]*/
 quoted_string : ESCAPED_STRING
 units: /\\[[^\\]]*\\]/

--- a/tests/test_parse_dai.py
+++ b/tests/test_parse_dai.py
@@ -1,0 +1,16 @@
+# pylint: disable=missing-module-docstring,missing-function-docstring
+from daisypy.io.dai_util import parse_dai, format_dai
+
+def test_leading_zeros_int():
+    text = '''(defprogram LeadingZeros Daisy
+    "Example" (time 1999 12 31) (stop 2001 01 01))'''
+    expected = '''(defprogram LeadingZeros Daisy
+  "Example" (time 1999 12 31) (stop 2001 1 1))'''
+    parsed = parse_dai(text)
+    assert format_dai(parsed) == expected
+
+def test_leading_zeros_float():
+    text = '''(defhorizon H (clay 00.39 [%]))'''
+    expected = '''(defhorizon H (clay 0.39 [%]))'''
+    parsed = parse_dai(text)
+    assert format_dai(parsed) == expected


### PR DESCRIPTION
Although the Daisy reference manuals states that leading zeros are not allowed, they are allowed in practice. Hence we can get dai files with leading zeros that we fail to parse if we dont allow leading zeros